### PR TITLE
Fix: template engine support for nested objects

### DIFF
--- a/libraries/html.js
+++ b/libraries/html.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { get } = require('lodash');
 
 // get root directory
 const rootDir = process.cwd();
@@ -23,7 +24,8 @@ const renderVars = (template = '', data = {}) => {
 
   return matches.reduce((html, placeholder) => {
     const prop = clean(placeholder);
-    return data[prop] ? html.replace(placeholder, data[prop]) : html;
+    const value = get(data, prop); // get value even if it's nested
+    return value ? html.replace(placeholder, value) : html;
   }, template);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1489,8 +1489,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lowercase-keys": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "dotenv": "^8.2.0",
+    "lodash": "^4.17.15",
     "mongoose": "^5.9.2"
   }
 }


### PR DESCRIPTION
Now the template engine supports nested objects as data.

Example:

```html
<h1>{{ title.value }}</h1>
```

```js
const data = {
   title: {
      value: 'This is a title'
   }
};
```