### PR TITLE
Fix: Major template engine bugs fixed

### DIFF
--- a/libraries/html.js
+++ b/libraries/html.js
@@ -20,7 +20,7 @@ const LOOP_VAR_REGEX = /\{%(?:(?!%\})(?:.|\n))*%\}/g;
 const clean = str => str.substring(2, str.length - 2).trim();
 
 const renderVars = (template = '', data = {}) => {
-  const matches = template.match(VAR_REGEX);
+  const matches = template.match(VAR_REGEX) || [];
 
   return matches.reduce((html, placeholder) => {
     const prop = clean(placeholder);
@@ -30,7 +30,7 @@ const renderVars = (template = '', data = {}) => {
 };
 
 const renderLoops = (template = '', data = {}) => {
-  const matches = template.match(LOOP_REGEX);
+  const matches = template.match(LOOP_REGEX) || [];
 
   return matches.reduce((html, loop) => {
     // get loop's variable name
@@ -66,9 +66,9 @@ const render = (filename, data = {}) => {
     encoding: 'utf8',
   });
 
-  const html = renderLoops(
+  const html = renderVars(
     // prettier-ignore
-    renderVars(template, data),
+    renderLoops(template, data),
     data
   );
   return html;


### PR DESCRIPTION
This PR fixes two major bugs:

- The engine couldn't render variables with the same name in different level of the data object

- When no loops or variables existed in the template the engine would normally crash